### PR TITLE
Fix setup crash: guard None self._last_state in InsnrgSensor.state

### DIFF
--- a/custom_components/insnrg_chlorinator/sensor.py
+++ b/custom_components/insnrg_chlorinator/sensor.py
@@ -103,7 +103,8 @@ class InsnrgConnectionSensor(RestoreEntity):
             return self._last_state.state if self._last_state is not None else "unknown"
         # Update the state based on the pool_chemistry data
         self._state = pool_chemistry.get(self._data_key)
-        self._last_state.state = self._state
+        if self._last_state is not None:
+            self._last_state.state = self._state
         return self._state
 
     @property


### PR DESCRIPTION
## Problem
`InsnrgSensor.state` unconditionally runs `self._last_state.state = self._state`. When `self._last_state` is `None` (e.g. an empty/absent reading during setup), this raises `AttributeError: 'NoneType' object has no attribute 'state'`, which aborts `async_setup_entry` (logged as "Error setting up entry INSNRG Chlorinator"). This looks like the failure reported in #2.

## Fix
Guard the assignment with a `None` check — matching the guard already present at the other two occurrences of this same line in `sensor.py` (the pH and ORP sensor classes). One-line behavioural change; no other logic touched.

## Testing
Applied against a live INSNRG chlorinator on Home Assistant 2026.6.x. The integration now sets up cleanly and all sensors (pH, ORP, set points, connection status, and the 4 timers) populate correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
